### PR TITLE
Re-draw placeholder when UITextView's layout or frame changes

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -88,12 +88,6 @@
 	[self setNeedsDisplay];
 }
 
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    [self setNeedsDisplay];
-}
-
 #pragma mark - NSObject
 
 - (void)dealloc {
@@ -155,6 +149,7 @@
 
 - (void)initialize {
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textChanged:) name:UITextViewTextDidChangeNotification object:self];
+	self.contentMode = UIViewContentModeRedraw;
 }
 
 


### PR DESCRIPTION
This happened to me when embedding textview into table view cell. In landscape mode it got stretched because of new frame.
