### PR TITLE
The `self.typingAttributes` will crash app in iOS6, it should be a bug o...

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -38,7 +38,7 @@
 	}
 	
 	NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
-	if (self.typingAttributes) {
+	if ([self isFirstResponder] && self.typingAttributes) {
 		[attributes addEntriesFromDictionary:self.typingAttributes];
 	} else {
 		attributes[NSFontAttributeName] = self.font;


### PR DESCRIPTION
...f iOS6. Since typingAttributes only available in editing mode, checking editing mode previously will fix the bug.
