### PR TITLE
The `self.typingAttributes` will crash app in iOS6

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -135,7 +135,12 @@
 		CGFloat padding = self.textContainer.lineFragmentPadding;
 		rect.origin.x += padding;
 		rect.size.width -= padding * 2.0f;
-	}
+	} else {
+        if (self.contentInset.left == 0.0f) {
+            rect.origin.x += 8.0f;
+        }
+        rect.origin.y += 8.0f;
+    }
 
 	return rect;
 }


### PR DESCRIPTION
The `self.typingAttributes` will crash app in iOS6, it should be a bug of iOS6. Since typingAttributes only available in editing mode, checking editing mode previously will fix the bug.
