### PR TITLE
Fix crashes and inconsistent behavior related to placeholder

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -85,6 +85,18 @@
 
 - (void)setFont:(UIFont *)font {
 	[super setFont:font];
+
+	NSMutableAttributedString *attributedPlaceholder = [self.attributedPlaceholder mutableCopy];
+	if (attributedPlaceholder) {
+		NSRange range = NSMakeRange(0, attributedPlaceholder.length);
+		if (font == nil) {
+			[attributedPlaceholder removeAttribute:NSFontAttributeName range:range];
+		} else {
+			[attributedPlaceholder addAttribute:NSFontAttributeName value:font range:range];
+		}
+		self.attributedPlaceholder = attributedPlaceholder;
+	}
+
 	[self setNeedsDisplay];
 }
 


### PR DESCRIPTION
This pull request fixes the following issues:
1. If you call `-setPlaceholder:` before setting the text view's `font`, an exception is thrown.
2. If you call `-setPlaceholder:` with a nil argument, an exception is thrown.
3. If you call `-setFont:` after `-setPlaceholder:`, the placeholder font is not updated.

Here are my [test cases](https://gist.github.com/cspickert/9592047).
