### PR TITLE
Fixed edge case in which placeholder text was cropped

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -131,7 +131,8 @@
 	CGRect rect = UIEdgeInsetsInsetRect(bounds, self.contentInset);
 
 	if ([self respondsToSelector:@selector(textContainer)]) {
-		rect = UIEdgeInsetsInsetRect(rect, self.textContainerInset);
+        	rect.origin.x += self.textContainerInset.left;
+        	rect.origin.y += self.textContainerInset.top;
 		CGFloat padding = self.textContainer.lineFragmentPadding;
 		rect.origin.x += padding;
 		rect.size.width -= padding * 2.0f;


### PR DESCRIPTION
In some cases -(CGRect)placeholderRectForBounds:(CGRect)bounds returned a smaller rectangle which caused placeholder text to be cropped (iOS 7 with 1 line text views, when using attributedPlaceholder).
