### PR TITLE
Redraw placeholder text if necessary when view layout changes.

### DIFF
--- a/SAMTextView/SAMTextView.m
+++ b/SAMTextView/SAMTextView.m
@@ -125,6 +125,16 @@
 }
 
 
+- (void)layoutSubviews
+{
+	[super layoutSubviews];
+
+	// Redraw placeholder text when the layout changes if necessary
+	if (self.text.length == 0 && self.attributedPlaceholder)
+		[self setNeedsDisplay];
+}
+
+
 #pragma mark - Placeholder
 
 - (CGRect)placeholderRectForBounds:(CGRect)bounds {


### PR DESCRIPTION
The placeholder text can be be distorted if the view layout changes, for example if the device rotates. This will redraw the placeholder text if it is visible.